### PR TITLE
Solve the problem that the bot sends "/new" prompt every time it replies

### DIFF
--- a/api/handle.py
+++ b/api/handle.py
@@ -28,7 +28,7 @@ def handle_message(update_data):
         chat = chat_manager.get_chat(update.from_id)
         anwser = chat.send_message(update.text)
         extra_text = (
-            "\n\nType /new to kick off a new chat." if chat.history_length >= 2 else ""
+            "\n\nType /new to kick off a new chat." if chat.history_length > 5 else ""
         )
         response_text = f"{anwser}{extra_text}"
         send_message(update.from_id, response_text)


### PR DESCRIPTION
Because one question and answer will increase `history_length` by `2`, the threshold is modified to `5,so that the user will be reminded after three questions and answers.