### PR TITLE
Support more media types + allow replying to previous media messages

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -25,13 +25,16 @@ GROUP_MODE = os.getenv("GROUP_MODE=", "1")
 #After setting up 3 rounds of dialogue, prompt the user to start a new dialogue
 prompt_new_threshold = int(3)
 
-#The default prompt when the photo has no accompanying text
-defaut_photo_caption = "describe this picture"
+# The default prompt when the photo has no accompanying text
+default_photo_caption = "describe this picture"
+default_media_caption = "transcribe this content"
 
 """ Below is some text related to the user """
-help_text = "You can send me text or pictures. When sending pictures, please include the text in the same message.\nTo use the group please @bot or reply to any message sent by the bot"
-command_list = "/new Start a new chat\n/get_my_info Get personal information\n/get_group_info Get group information (group only)\n/get_allowed_users Get the list of users that are allowed to use the bot (admin only)\n/get_allowed_groups Get the list of groups that are allowed to use the bot (admin only)\n/list_models list_models (admin only)\n/get_api_key Get the list of gemini's apikeys. It is currently useless. Multiple keys may be added to automatically switch in the future.(admin only)\n/help Get help\n/5g_test :)"
-admin_auch_info = "You are not the administrator or your administrator ID is set incorrectly!!!"
+help_text = "You can send me text, pictures, videos, audios, and voice/video messages. When sending media, please include the prompt in the same message or reply to the media with the prompt. If not prompt is provided for a media file, the default one will be used.\nTo use the group please @bot or reply to any message sent by the bot"
+command_list = "/new Start a new chat\n/get_my_info Get personal information\n/get_group_info Get group information (group only)\n/get_allowed_users Get the list of users that are allowed to use the bot (admin only)\n/get_allowed_groups Get the list of groups that are allowed to use the bot (admin only)\n/list_models list_models (admin only)\n/get_api_key Get the list of gemini's apikeys. It is currently useless. Multiple keys may be added to automatically switch in the future.(admin only)\n/help Get help\n"
+admin_auch_info = (
+    "You are not the administrator or your administrator ID is set incorrectly!!!"
+)
 debug_mode_info = "Debug mode is not enabled!"
 command_format_error_info = "Command format error"
 command_invalid_error_info = "Invalid command, use /help for help"

--- a/api/context.py
+++ b/api/context.py
@@ -14,8 +14,8 @@ from typing import Dict
 
 import requests
 
-from .config import BOT_TOKEN
-from .gemini import ChatConversation, generate_text_with_image
+from .gemini import ChatConversation, generate_text_with_image, generate_text_with_file
+from .telegram import get_file_content, get_file_url
 
 
 class ChatManager:
@@ -40,22 +40,28 @@ class ImageChatManger:
         self.prompt = prompt
         self.file_id = file_id
 
-    def tel_photo_url(self) -> str:
-        """process telegram photo url"""
-        r_file_id = requests.get(
-            f"https://api.telegram.org/bot{BOT_TOKEN}/getFile?file_id={self.file_id}"
-        )
-        file_path = r_file_id.json().get("result").get("file_path")
-        download_url = f"https://api.telegram.org/file/bot{BOT_TOKEN}/{file_path}"
-        return download_url
-
     def photo_bytes(self) -> BytesIO:
         """get photo bytes"""
-        photo_url = self.tel_photo_url()
+        photo_url = get_file_url(self.file_id)
         response = requests.get(photo_url)
         photo_bytes = BytesIO(response.content)
         return photo_bytes
 
     def send_image(self) -> str:
         response = generate_text_with_image(self.prompt, self.photo_bytes())
+        return response
+
+
+class MediaChatManager:
+    def __init__(self, media_type, mime_type, file_id, prompt):
+        self.media_type = media_type
+        self.mime_type = mime_type
+        self.file_id = file_id
+        self.prompt = prompt
+        self.file_url = get_file_url(self.file_id)
+
+    def send_media(self):
+        file_bytes = get_file_content(self.file_url)
+
+        response = generate_text_with_file(self.prompt, file_bytes, self.mime_type)
         return response

--- a/api/gemini.py
+++ b/api/gemini.py
@@ -1,9 +1,14 @@
 from io import BytesIO
 
 from google import genai
+from google.genai import types
 import PIL.Image
 
-from .config import GOOGLE_API_KEY, generation_config, safety_settings, gemini_err_info, new_chat_info
+from .config import (
+    GOOGLE_API_KEY,
+    gemini_err_info,
+    new_chat_info,
+)
 
 client = genai.Client(api_key=GOOGLE_API_KEY[0])
 
@@ -29,7 +34,23 @@ def generate_text_with_image(prompt: str, image_bytes: BytesIO) -> str:
     """generate text from prompt and image"""
     img = PIL.Image.open(image_bytes)
     try:
-        response = client.models.generate_content(model=_MODEL_VERSION, contents=[prompt, img])
+        response = client.models.generate_content(
+            model=_MODEL_VERSION, contents=[prompt, img]
+        )
+        result = response.text
+    except Exception as e:
+        result = f"{gemini_err_info}\n{repr(e)}"
+    return result
+
+
+def generate_text_with_file(prompt: str, file_bytes: bytes, mime_type: str) -> str:
+    """generate text from prompt and file"""
+    try:
+        media_part = types.Part.from_bytes(data=file_bytes, mime_type=mime_type)
+        response = client.models.generate_content(
+            model=_MODEL_VERSION,
+            contents=[prompt, media_part],
+        )
         result = response.text
     except Exception as e:
         result = f"{gemini_err_info}\n{repr(e)}"

--- a/api/handle.py
+++ b/api/handle.py
@@ -13,9 +13,9 @@ them pretty straight-up without much fuss.
 
 from .auth import is_authorized
 from .command import excute_command
-from .context import ChatManager, ImageChatManger
-from .telegram import Update, send_message
-from .printLog import send_log,send_image_log
+from .context import ChatManager, MediaChatManager
+from .telegram import Update, send_message, send_reaction
+from .printLog import send_log
 from .config import *
 
 chat_manager = ChatManager()
@@ -33,12 +33,31 @@ def handle_message(update_data):
     #    send_message(admin_id, f"收到了一个未知事件，原文为：\n{update_data}\n错误为：\n{e}")
 
     update = Update(update_data)
-    if update.is_group :
+
+    is_reply = "reply_to_message" in update_data["message"]
+    target_update = (
+        Update({"message": update_data["message"]["reply_to_message"]})
+        if is_reply
+        else None
+    )
+    target_update_media = (
+        update.type == "text" and is_reply and target_update.media_type is not None
+    )
+
+    if update.is_group:
         log = f"{event_received}\n@{update.user_name} id:`{update.from_id}` {group} @{update.group_name} id:`{update.chat_id}`\n{the_content_sent_is}\n{update.text}\n```json\n{update_data}```"
     else:
         log = f"{event_received}\n@{update.user_name} id:`{update.from_id}`\n{the_content_sent_is}\n{update.text}\n```json\n{update_data}```"
     send_log(log)
-    authorized = is_authorized(update.is_group, update.from_id, update.user_name,  update.chat_id, update.group_name)
+    authorized = is_authorized(
+        update.is_group,
+        update.from_id,
+        update.user_name,
+        update.chat_id,
+        update.group_name,
+    )
+
+    send_reaction(update.chat_id, update.message_id, "👍")
 
     if update.type == "command":
         response_text = excute_command(update.from_id, update.text, update.from_type, update.chat_id)
@@ -61,6 +80,34 @@ def handle_message(update_data):
         send_log(log)
         return
 
+    elif target_update_media or update.media_type is not None:
+        media_update = target_update if target_update_media else update
+        prompt = (
+            update.text
+            if is_reply
+            else (media_update.caption or "Transcribe or describe this.")
+        )
+        chat = MediaChatManager(
+            media_update.media_type,
+            media_update.mime_type,
+            media_update.file_id,
+            prompt,
+        )
+        response_text = chat.send_media()
+        print(f"update.message_id {update.message_id}")
+        # Use the reply_to_message_id parameter to let the bot reply to
+        # a specific image.
+        send_message(
+            update.chat_id, response_text, reply_to_message_id=update.message_id
+        )
+
+        file_url = chat.file_url
+        if update.is_group:
+            log = f"@{update.user_name} id:`{update.from_id}` {group} @{update.group_name} id:`{update.chat_id}`[file]({file_url}),{the_accompanying_message_is}\n{prompt}\n{the_reply_content_is}\n{response_text}"
+        else:
+            log = f"@{update.user_name} id:`{update.from_id}`[file]({file_url}),{the_accompanying_message_is}\n{prompt}\n{the_reply_content_is}\n{response_text}"
+        send_log(log)
+
     elif update.type == "text":
         if update.is_group and GROUP_MODE == "2":
             history_id = update.from_id
@@ -78,25 +125,6 @@ def handle_message(update_data):
             log = f"@{update.user_name} id:`{update.from_id}` {group} @{update.group_name} id:`{update.chat_id}`{the_content_sent_is}\n{update.text}\n{the_reply_content_is}\n{response_text}\n{the_logarithm_of_historical_conversations_is}{dialogueLogarithm}"
         else:
             log = f"@{update.user_name} id:`{update.from_id}`{the_content_sent_is}\n{update.text}\n{the_reply_content_is}\n{response_text}\n{the_logarithm_of_historical_conversations_is}{dialogueLogarithm}"
-        send_log(log)
-
-    elif update.type == "photo":
-        chat = ImageChatManger(update.photo_caption, update.file_id)
-        response_text = chat.send_image()
-        print(f"update.message_id {update.message_id}")
-        # Use the reply_to_message_id parameter to let the bot reply to
-        # a specific image.
-        send_message(
-            update.chat_id, response_text, reply_to_message_id=update.message_id
-        )
-
-        photo_url = chat.tel_photo_url()
-        imageID = update.file_id
-        if update.is_group:
-            log = f"@{update.user_name} id:`{update.from_id}` {group} @{update.group_name} id:`{update.chat_id}`[photo]({photo_url}),{the_accompanying_message_is}\n{update.photo_caption}\n{the_reply_content_is}\n{response_text}"
-        else:
-            log = f"@{update.user_name} id:`{update.from_id}`[photo]({photo_url}),{the_accompanying_message_is}\n{update.photo_caption}\n{the_reply_content_is}\n{response_text}"
-        send_image_log("", imageID)
         send_log(log)
 
     else:

--- a/api/index.py
+++ b/api/index.py
@@ -9,6 +9,9 @@ app = Flask(__name__)
 def home():
     if request.method == "POST":
         update = request.json
-        handle_message(update)
+        try:
+            handle_message(update)
+        except Exception as e:
+            print(f"Error while handling update: {repr(e)}")
         return "ok"
     return render_template("status.html")

--- a/api/telegram.py
+++ b/api/telegram.py
@@ -1,9 +1,17 @@
-from typing import Dict
+from typing import Dict, Literal
 
 import requests
 from md2tgmd import escape
 
-from .config import BOT_TOKEN, defaut_photo_caption, send_message_log, send_photo_log, unnamed_user, unnamed_group
+from .config import (
+    BOT_TOKEN,
+    default_photo_caption,
+    default_media_caption,
+    send_message_log,
+    send_photo_log,
+    unnamed_user,
+    unnamed_group,
+)
 from .printLog import send_log
 
 TELEGRAM_API = f"https://api.telegram.org/bot{BOT_TOKEN}"
@@ -11,6 +19,7 @@ TELEGRAM_API = f"https://api.telegram.org/bot{BOT_TOKEN}"
 
 def send_message(chat_id, text, **kwargs):
     """send text message"""
+    print(f"Sending message: {text} to {chat_id}")
     payload = {
         "chat_id": chat_id,
         "text": escape(text),
@@ -29,12 +38,44 @@ def send_imageMessage(chat_id, text, imageID):
         "chat_id": chat_id,
         "caption": escape(text),
         "parse_mode": "MarkdownV2",
-        "photo": imageID
+        "photo": imageID,
     }
     r = requests.post(f"{TELEGRAM_API}/sendPhoto", data=payload)
     print(f"Sent imageMessage: {text} to {chat_id}")
     send_log(f"{send_photo_log}\n```json\n{str(r)}```")
     return r
+
+
+def send_reaction(chat_id, message_id, emoji="👍"):
+    url = f"{TELEGRAM_API}/setMessageReaction"
+    payload = {
+        "chat_id": chat_id,
+        "message_id": message_id,
+        "reaction": [{"type": "emoji", "emoji": emoji}],
+        "is_big": False,
+    }
+    return requests.post(url, json=payload)
+
+
+def get_file_url(file_id) -> str:
+    """process telegram photo url"""
+    r_file_id = requests.get(f"{TELEGRAM_API}/getFile?file_id={file_id}")
+    file_path = r_file_id.json().get("result").get("file_path")
+    download_url = f"https://api.telegram.org/file/bot{BOT_TOKEN}/{file_path}"
+    print(f"Found download link for {file_id}: {download_url}")
+    return download_url
+
+
+def get_file_content(file_url):
+    file_res = requests.get(file_url)
+    print(f"Content downloaded [{len(file_res.content)}] from {file_url}")
+    print(f"Content: {file_res.content}")
+    return file_res.content
+
+
+UpdateType = Literal[
+    "command", "text", "voice", "video_note", "video", "audio", "photo", ""
+]
 
 
 class Update:
@@ -44,13 +85,20 @@ class Update:
         self.chat_id = update["message"]["chat"]["id"]
         self.from_type = update["message"]["chat"]["type"]
         self.is_group: bool = self._is_group()
-        self.type = self._type()
+        self.type: UpdateType = self._type()
+        self.media_type = self._media_type()
+        self.mime_type = self._mime_type()
         self.text = self._text()
-        self.photo_caption = self._photo_caption()
+        self.caption = self._caption()
         self.file_id = self._file_id()
-        #self.user_name = update["message"]["from"]["username"]
-        self.user_name = update["message"]["from"].get("username", f" [{unnamed_user}](tg://openmessage?user_id={self.from_id})")
-        self.group_name = update["message"]["chat"].get("username", f" [{unnamed_group}](tg://openmessage?chat_id={str(self.chat_id)[4:]})")
+        # self.user_name = update["message"]["from"]["username"]
+        self.user_name = update["message"]["from"].get(
+            "username", f" [{unnamed_user}](tg://openmessage?user_id={self.from_id})"
+        )
+        self.group_name = update["message"]["chat"].get(
+            "username",
+            f" [{unnamed_group}](tg://openmessage?chat_id={str(self.chat_id)[4:]})",
+        )
         self.message_id: int = update["message"]["message_id"]
 
     def _is_group(self):
@@ -59,19 +107,37 @@ class Update:
         return False
 
     def _type(self):
-        if "text" in self.update["message"]:
-            text = self.update["message"]["text"]
+        msg = self.update["message"]
+        if "text" in msg:
+            text = msg["text"]
             if text.startswith("/") and not text.startswith("/new"):
                 return "command"
             return "text"
-        elif "photo" in self.update["message"]:
+        elif "voice" in msg:
+            return "voice"
+        elif "video_note" in msg:
+            return "video_note"
+        elif "video" in msg:
+            return "video"
+        elif "audio" in msg:
+            return "audio"
+        elif "photo" in msg:
             return "photo"
         else:
             return ""
 
-    def _photo_caption(self):
-        if self.type == "photo":
-            return self.update["message"].get("caption", defaut_photo_caption)
+    def _media_type(self):
+        return self.type if self.type != "text" and self.type != "command" else None
+
+    def _caption(self):
+        if self.media_type is not None:
+            caption = self.update["message"].get("caption")
+            if caption is not None and caption != "":
+                return caption
+            elif self.media_type == "photo":
+                return default_photo_caption
+            else:
+                return default_media_caption
         return ""
 
     def _text(self):
@@ -84,6 +150,29 @@ class Update:
         return ""
 
     def _file_id(self):
-        if self.type == "photo":
-            return self.update["message"]["photo"][-1]["file_id"]
+        msg = self.update["message"]
+        if self.type == "voice":
+            return msg["voice"]["file_id"]
+        elif self.type == "video_note":
+            return msg["video_note"]["file_id"]
+        elif self.type == "video":
+            return msg["video"]["file_id"]
+        elif self.type == "audio":
+            return msg["audio"]["file_id"]
+        elif self.type == "photo":
+            return msg["photo"][-1]["file_id"]
         return ""
+
+    def _mime_type(self):
+        msg = self.update["message"]
+        if self.type == "voice":
+            return msg["voice"].get("mime_type", "audio/ogg")
+        elif self.type == "video_note":
+            return msg["video_note"].get("mime_type", "video/mp4")
+        elif self.type == "video":
+            return msg["video"].get("mime_type", "video/mp4")
+        elif self.type == "audio":
+            return msg["audio"].get("mime_type", "audio/mpeg")
+        elif self.type == "photo":
+            return msg["photo"][-1].get("mime_type", "image/jpeg")
+        return "application/octet-stream"


### PR DESCRIPTION
Hello,

I wanted to use this bot to transcribe video/audio messages, so I added support for these kinds of media files. Since I was doing that, I added support for videos and audio.

Additionally, you can now reply to a previously sent media file and send a custom prompt.

Example:
1. The user sends a photo (or video, audio, voice/video message)
2. bot replies to photo with description
3. user replies to msg 1 with text: What is the main colour?
4. bot replies to photo with the response to the prompt received in msg 3

Finally, I updated the bot to react to prompts, so that it's clear that it's processing them.